### PR TITLE
Ability to pick theme; added pre_option for theme

### DIFF
--- a/easydebug.php
+++ b/easydebug.php
@@ -2,12 +2,15 @@
 /**
  * Plugin Name: Easy Debug
  * Description: Easily disable plugins and switch to a default theme using query strings.
- * Version: 0.0.1
- * Author: Jason Stallings
+ * Version: 0.0.2
+ * Author: Jason Stallings, John Dittmar
  * Author URI: http://github.com/octalmage/
  */
 
-add_action("init","easydebug_filters");
+add_action("init", "easydebug_filters");
+
+add_filter("pre_option_template", "easydebug_theme");
+add_filter("pre_option_stylesheet", "easydebug_theme");
 
 add_filter("pre_option_active_plugins", "easydebug_plugins");
 add_filter("pre_site_option_active_sitewide_plugins", "easydebug_plugins");
@@ -20,9 +23,32 @@ function easydebug_filters()
 
 function easydebug_theme($theme)
 {
-    if ($_GET["defaulttheme"]==1)
+    if ( isset($_GET["theme"]) )
     {   
-        return "twentyfifteen";
+        $themes = wp_get_themes();
+
+        if ( array_key_exists($_GET["theme"], $themes) )
+        {
+            return $_GET["theme"];
+        }
+
+        $default_themes = array_filter(array_keys($themes), function($k) 
+        {
+            return strpos($k, 'twenty') !== false;
+        }); 
+
+        $default_themes = array_intersect(array_keys($themes), $default_themes);
+
+        if ( !empty($default_themes) ) 
+        {
+            $index = 0;
+            if ( is_numeric($_GET["theme"]) ) 
+            {
+                $requested_index = (int) $_GET["theme"];
+                $index = isset($default_themes[$requested_index]) ? $requested_index : 0;
+            }
+            return $default_themes[$index]; 
+        } 
     }   
     return $theme;
 }
@@ -30,7 +56,7 @@ function easydebug_theme($theme)
 
 function easydebug_plugins($plugins)
 {
-    if ($_GET["disableplugins"]==1)
+    if ( $_GET["disableplugins"] == 1)
     {   
         return array();
     }   

--- a/easydebug.php
+++ b/easydebug.php
@@ -7,19 +7,11 @@
  * Author URI: http://github.com/octalmage/
  */
 
-add_action("init", "easydebug_filters");
-
 add_filter("pre_option_template", "easydebug_theme");
 add_filter("pre_option_stylesheet", "easydebug_theme");
 
 add_filter("pre_option_active_plugins", "easydebug_plugins");
 add_filter("pre_site_option_active_sitewide_plugins", "easydebug_plugins");
-
-function easydebug_filters()
-{
-    add_filter("template", "easydebug_theme");
-    add_filter("stylesheet", "easydebug_theme");
-}
 
 function easydebug_theme($theme)
 {


### PR DESCRIPTION
Added nifty filters for pre_options for theme/stylesheet to make sure the overrided theme hooks are executed.

You can also do https://site.com/?theme=1 or https://site.com/?theme=twentytwelve
